### PR TITLE
chore: workflow and dependencies udpate

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -5,31 +5,35 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm i
-    - run: npm run build --if-present
-    - run: npm test
-    - run: npm run coverage
+      - uses: actions/checkout@v4
 
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - run: npm i
+
+      - run: npm run build --if-present
+
+      - run: npm test
+
+      - run: npm run coverage
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking change
 
 - time is not displayed in seconds but in milliseconds
+- update `kafkajs` to `v2.0.0` and other development dependencies
 
 ## v1.0.0 - 2021-01-15
 

--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "postcoverage": "tap --coverage-report=html --no-browser"
   },
   "dependencies": {
-    "pino": "^6.10.0"
+    "pino": "^8.15.1"
   },
   "devDependencies": {
     "@mia-platform/eslint-config-mia": "^3.0.0",
-    "ajv": "^7.0.3",
-    "eslint": "^7.17.0",
-    "kafkajs": "^1.15.0",
+    "ajv": "^8.12.0",
+    "eslint": "^8.49.0",
+    "kafkajs": "^2.2.4",
     "tap": "^16.3.7"
   },
   "peerDependencies": {


### PR DESCRIPTION
In this PR are updated:

- `checkout` and `setup-node` actions to their latest version
- `pino` is bumped from `v6.x` to `v8.x`
- `kafkajs` is bumped from `v1.15.0` to `v2.0.0`
- other minor development dependencies 